### PR TITLE
Remove a line being logged repeatedly

### DIFF
--- a/Sources/AbletonPushDisplayKit/Push 2 Display/Push2DisplayManager.swift
+++ b/Sources/AbletonPushDisplayKit/Push 2 Display/Push2DisplayManager.swift
@@ -78,12 +78,7 @@ class Push2DisplayManager: Push2DisplayManagerProtocol {
     
     
     @objc private func sendPixels(pixels: [UInt8]) {
-        if !self.isConnected {
-            print("Connect before sending pixels.")
-            return
-        }
-        
-        guard let interface = self.deviceInterface else {
+        guard isConnected, let interface = self.deviceInterface else {
             return
         }
         


### PR DESCRIPTION
Removed a print statement from a method which is called 12 times per second, causing the console to be unusable for debugging. 