### PR TITLE
Add Push display frame mirroring sinks

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,9 @@ let package = Package(
         .executable(
             name: "PushDebug",
             targets: ["PushDebug"]),
+        .executable(
+            name: "PushDisplayMirrorApp",
+            targets: ["PushDisplayMirrorApp"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -27,6 +30,9 @@ let package = Package(
             dependencies: []),
         .executableTarget(
             name: "PushDebug",
+            dependencies: ["AbletonPushDisplayKit"]),
+        .executableTarget(
+            name: "PushDisplayMirrorApp",
             dependencies: ["AbletonPushDisplayKit"]),
         .testTarget(
             name: "AbletonPushDisplayKitTests",

--- a/Sources/AbletonPushDisplayKit/PushDisplay/PixelExtractor.swift
+++ b/Sources/AbletonPushDisplayKit/PushDisplay/PixelExtractor.swift
@@ -3,11 +3,11 @@ import SwiftUI
 
 typealias Pixel = UInt8
 
-class PixelExtractor {
+public enum PixelExtractor {
     public static let DISPLAY_WIDTH = 960
     public static let DISPLAY_HEIGHT = 160
     
-    static func getPixelsForPush(bitmap: NSBitmapImageRep) -> [UInt8] {
+    public static func getPixelsForPush(bitmap: NSBitmapImageRep) -> [UInt8] {
         let displayPitch = 1920 + 128
         var processedImage = [UInt8](repeating: 0, count: displayPitch * DISPLAY_HEIGHT)
 

--- a/Sources/AbletonPushDisplayKit/PushDisplay/Push2DisplayManagerProtocol.swift
+++ b/Sources/AbletonPushDisplayKit/PushDisplay/Push2DisplayManagerProtocol.swift
@@ -13,6 +13,9 @@ protocol PushDisplayManagerProtocol {
     var isConnected: Bool { get }
     func connect(completion: @escaping (Result<Bool, Error>) -> Void)
     func connect(to device: PushDevice, completion: @escaping (Result<Bool, Error>) -> Void)
+    func addFrameSink(_ sink: PushDisplayFrameSink)
+    func removeFrameSink(_ sink: PushDisplayFrameSink)
+    func removeAllFrameSinks()
     func sendPixels(pixels: [UInt8])
     func disconnect()
 }

--- a/Sources/AbletonPushDisplayKit/PushDisplay/PushDisplayFrame.swift
+++ b/Sources/AbletonPushDisplayKit/PushDisplay/PushDisplayFrame.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// A single Push display frame at the same encoded boundary used by the USB transport.
+///
+/// `encodedPixels` is the Push-ready payload produced by `PixelExtractor.getPixelsForPush`:
+/// 960×160 pixels, BGR565 little-endian, XOR-shaped, with 128 bytes of row padding.
+/// This is the lowest-friction mirror point because the same bytes can be sent to
+/// hardware, recorded, streamed to a preview process, or decoded for a web canvas.
+public struct PushDisplayFrame: Equatable {
+    public static let width = 960
+    public static let height = 160
+    public static let bytesPerPixel = 2
+    public static let rowPixelBytes = width * bytesPerPixel
+    public static let rowPaddingBytes = 128
+    public static let rowStride = rowPixelBytes + rowPaddingBytes
+    public static let encodedByteCount = rowStride * height
+
+    private static let xorPattern: [UInt8] = [0xE7, 0xF3, 0xE7, 0xFF]
+
+    public let encodedPixels: [UInt8]
+    public let timestamp: Date
+
+    public init(encodedPixels: [UInt8], timestamp: Date = Date()) {
+        self.encodedPixels = encodedPixels
+        self.timestamp = timestamp
+    }
+
+    public var isValidForPushDisplay: Bool {
+        encodedPixels.count == Self.encodedByteCount
+    }
+
+    /// Decodes the Push-ready BGR565/XOR payload into tightly packed RGB888 bytes.
+    /// Row padding is ignored. Invalid/truncated frames return an empty buffer.
+    public func decodedRGB888Bytes() -> [UInt8] {
+        guard isValidForPushDisplay else { return [] }
+
+        var decoded = [UInt8](repeating: 0, count: Self.width * Self.height * 3)
+
+        for y in 0 ..< Self.height {
+            let sourceRow = y * Self.rowStride
+            let destRow = y * Self.width * 3
+
+            for x in 0 ..< Self.width {
+                let sourceOffset = sourceRow + x * Self.bytesPerPixel
+                let byte0 = encodedPixels[sourceOffset] ^ Self.xorPattern[(x * 2) & 3]
+                let byte1 = encodedPixels[sourceOffset + 1] ^ Self.xorPattern[(x * 2 + 1) & 3]
+                let bgr565 = UInt16(byte0) | (UInt16(byte1) << 8)
+
+                let r5 = UInt8(bgr565 & 0x1F)
+                let g6 = UInt8((bgr565 >> 5) & 0x3F)
+                let b5 = UInt8((bgr565 >> 11) & 0x1F)
+
+                let destOffset = destRow + x * 3
+                decoded[destOffset] = (r5 << 3) | (r5 >> 2)
+                decoded[destOffset + 1] = (g6 << 2) | (g6 >> 4)
+                decoded[destOffset + 2] = (b5 << 3) | (b5 >> 2)
+            }
+        }
+
+        return decoded
+    }
+
+    /// Decodes the Push-ready BGR565/XOR payload into tightly packed RGBA8888 bytes.
+    /// This is convenient for browser `ImageData` and native preview views.
+    public func decodedRGBA8888Bytes(alpha: UInt8 = 255) -> [UInt8] {
+        guard isValidForPushDisplay else { return [] }
+
+        var decoded = [UInt8](repeating: 0, count: Self.width * Self.height * 4)
+
+        for y in 0 ..< Self.height {
+            let sourceRow = y * Self.rowStride
+            let destRow = y * Self.width * 4
+
+            for x in 0 ..< Self.width {
+                let sourceOffset = sourceRow + x * Self.bytesPerPixel
+                let byte0 = encodedPixels[sourceOffset] ^ Self.xorPattern[(x * 2) & 3]
+                let byte1 = encodedPixels[sourceOffset + 1] ^ Self.xorPattern[(x * 2 + 1) & 3]
+                let bgr565 = UInt16(byte0) | (UInt16(byte1) << 8)
+
+                let r5 = UInt8(bgr565 & 0x1F)
+                let g6 = UInt8((bgr565 >> 5) & 0x3F)
+                let b5 = UInt8((bgr565 >> 11) & 0x1F)
+
+                let destOffset = destRow + x * 4
+                decoded[destOffset] = (r5 << 3) | (r5 >> 2)
+                decoded[destOffset + 1] = (g6 << 2) | (g6 >> 4)
+                decoded[destOffset + 2] = (b5 << 3) | (b5 >> 2)
+                decoded[destOffset + 3] = alpha
+            }
+        }
+
+        return decoded
+    }
+}
+
+/// Receives each encoded Push display frame without taking ownership of the hardware path.
+/// Implementations can record frames, forward them over a websocket, update a local preview,
+/// or bridge decoded bytes into a web view.
+public protocol PushDisplayFrameSink: AnyObject {
+    func receive(pushDisplayFrame frame: PushDisplayFrame)
+}
+
+/// Lightweight adapter for callers that want to attach a closure as a mirror sink.
+public final class ClosurePushDisplayFrameSink: PushDisplayFrameSink {
+    private let handler: (PushDisplayFrame) -> Void
+
+    public init(_ handler: @escaping (PushDisplayFrame) -> Void) {
+        self.handler = handler
+    }
+
+    public func receive(pushDisplayFrame frame: PushDisplayFrame) {
+        handler(frame)
+    }
+}

--- a/Sources/AbletonPushDisplayKit/PushDisplay/PushDisplayManager.swift
+++ b/Sources/AbletonPushDisplayKit/PushDisplay/PushDisplayManager.swift
@@ -42,6 +42,9 @@ public class PushDisplayManager: PushDisplayManagerProtocol {
     private var reconnectTimer: Timer?
     private var isConnecting = false
     private var lastDisconnectTime: Date?
+    private var frameSinks: [PushDisplayFrameSink] = []
+    private let frameSinksLock = NSLock()
+    private let frameSinksQueue = DispatchQueue(label: "PushDisplayManager.frameSinks", qos: .userInitiated)
 
     public init() {
         startObservingDevices()
@@ -163,7 +166,31 @@ public class PushDisplayManager: PushDisplayManagerProtocol {
         }
     }
 
+    public func addFrameSink(_ sink: PushDisplayFrameSink) {
+        frameSinksLock.lock()
+        defer { frameSinksLock.unlock() }
+
+        guard !frameSinks.contains(where: { $0 === sink }) else { return }
+        frameSinks.append(sink)
+    }
+
+    public func removeFrameSink(_ sink: PushDisplayFrameSink) {
+        frameSinksLock.lock()
+        defer { frameSinksLock.unlock() }
+
+        frameSinks.removeAll { $0 === sink }
+    }
+
+    public func removeAllFrameSinks() {
+        frameSinksLock.lock()
+        defer { frameSinksLock.unlock() }
+
+        frameSinks.removeAll()
+    }
+
     @objc public func sendPixels(pixels: [UInt8]) {
+        publishFrameToSinks(PushDisplayFrame(encodedPixels: pixels))
+
         guard isConnected, let interface = deviceInterface else { return }
 
         do {
@@ -176,6 +203,20 @@ public class PushDisplayManager: PushDisplayManagerProtocol {
         } catch {
             NSLog("PushDisplayManager: Send failed, disconnecting")
             handleDisconnection()
+        }
+    }
+
+    private func publishFrameToSinks(_ frame: PushDisplayFrame) {
+        frameSinksLock.lock()
+        let sinks = frameSinks
+        frameSinksLock.unlock()
+
+        guard !sinks.isEmpty else { return }
+
+        frameSinksQueue.async {
+            for sink in sinks {
+                sink.receive(pushDisplayFrame: frame)
+            }
         }
     }
 
@@ -193,7 +234,7 @@ public class PushDisplayManager: PushDisplayManagerProtocol {
         return connectedDevices
     }
 
-    func disconnect() {
+    public func disconnect() {
         try? deviceInterface?.close()
         deviceInterface?.release()
         deviceInterface = nil

--- a/Sources/AbletonPushDisplayKit/PushDisplay/PushDisplayMirrorWindowController.swift
+++ b/Sources/AbletonPushDisplayKit/PushDisplay/PushDisplayMirrorWindowController.swift
@@ -1,0 +1,66 @@
+import AppKit
+import Foundation
+
+/// A native macOS preview window that mirrors the exact Push frame stream.
+///
+/// This is useful when you want to run PushOS normally while also seeing the
+/// transport-layer output on the computer. Frames arrive as Push-ready BGR565 +
+/// XOR payloads and are decoded to RGBA before being displayed.
+public final class PushDisplayMirrorWindowController: NSWindowController, PushDisplayFrameSink {
+    private let imageView: NSImageView
+    private let colorSpace = CGColorSpaceCreateDeviceRGB()
+
+    public init() {
+        imageView = NSImageView(frame: NSRect(x: 0, y: 0, width: PushDisplayFrame.width, height: PushDisplayFrame.height))
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        imageView.wantsLayer = true
+        imageView.layer?.magnificationFilter = .nearest
+        imageView.layer?.minificationFilter = .nearest
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 120, y: 120, width: PushDisplayFrame.width, height: PushDisplayFrame.height),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "PushOS Display Mirror"
+        window.contentAspectRatio = NSSize(width: PushDisplayFrame.width, height: PushDisplayFrame.height)
+        window.contentView = imageView
+
+        super.init(window: window)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public func receive(pushDisplayFrame frame: PushDisplayFrame) {
+        let rgba = frame.decodedRGBA8888Bytes()
+        guard !rgba.isEmpty else { return }
+        guard let cgImage = makeImage(fromRGBA: rgba) else { return }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.imageView.image = NSImage(cgImage: cgImage, size: NSSize(width: PushDisplayFrame.width, height: PushDisplayFrame.height))
+        }
+    }
+
+    private func makeImage(fromRGBA rgba: [UInt8]) -> CGImage? {
+        let data = Data(rgba)
+        guard let provider = CGDataProvider(data: data as CFData) else { return nil }
+
+        return CGImage(
+            width: PushDisplayFrame.width,
+            height: PushDisplayFrame.height,
+            bitsPerComponent: 8,
+            bitsPerPixel: 32,
+            bytesPerRow: PushDisplayFrame.width * 4,
+            space: colorSpace,
+            bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.last.rawValue),
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent
+        )
+    }
+}

--- a/Sources/AbletonPushDisplayKit/PushDisplay/PushDisplayTCPMirror.swift
+++ b/Sources/AbletonPushDisplayKit/PushDisplay/PushDisplayTCPMirror.swift
@@ -1,0 +1,200 @@
+import Foundation
+import Network
+import QuartzCore
+
+private let pushDisplayMirrorMagic = Data([0x50, 0x53, 0x4D, 0x46]) // PSMF: PushOS Mirror Frame
+private let pushDisplayMirrorHeaderByteCount = 8
+
+/// Sends encoded Push display frames to a separate mirror process over localhost TCP.
+///
+/// This keeps mirroring out of the PushOS process. The receiving process can be
+/// stopped/restarted independently and can throttle/decode/display frames without
+/// affecting the hardware transport path.
+public final class PushDisplayTCPFrameSink: PushDisplayFrameSink {
+    private let host: NWEndpoint.Host
+    private let port: NWEndpoint.Port
+    private let minimumFrameInterval: TimeInterval
+    private let queue = DispatchQueue(label: "PushDisplayTCPFrameSink")
+    private var connection: NWConnection?
+    private var isReady = false
+    private var lastSentAt: TimeInterval = 0
+    private var didLogReady = false
+
+    public init(host: String = "127.0.0.1", port: UInt16 = 48484, maxFPS: Double = 15) {
+        self.host = NWEndpoint.Host(host)
+        self.port = NWEndpoint.Port(rawValue: port)!
+        self.minimumFrameInterval = maxFPS > 0 ? 1.0 / maxFPS : 0
+        queue.async { [weak self] in
+            self?.connect()
+        }
+    }
+
+    public func receive(pushDisplayFrame frame: PushDisplayFrame) {
+        guard frame.isValidForPushDisplay else { return }
+
+        let now = CACurrentMediaTime()
+        guard now - lastSentAt >= minimumFrameInterval else { return }
+        lastSentAt = now
+
+        let encodedPixels = frame.encodedPixels
+        queue.async { [weak self] in
+            self?.send(encodedPixels)
+        }
+    }
+
+    private func connect() {
+        guard connection == nil else { return }
+
+        let connection = NWConnection(host: host, port: port, using: .tcp)
+        self.connection = connection
+        isReady = false
+
+        connection.stateUpdateHandler = { [weak self] state in
+            self?.queue.async {
+                self?.handleConnectionState(state)
+            }
+        }
+        connection.start(queue: queue)
+    }
+
+    private func handleConnectionState(_ state: NWConnection.State) {
+        switch state {
+        case .ready:
+            isReady = true
+            if !didLogReady {
+                NSLog("PushDisplayTCPFrameSink: connected to mirror at \(host):\(port)")
+                didLogReady = true
+            }
+        case .failed, .cancelled:
+            reconnect()
+        default:
+            break
+        }
+    }
+
+    private func reconnect() {
+        connection?.cancel()
+        connection = nil
+        isReady = false
+        queue.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.connect()
+        }
+    }
+
+    private func send(_ encodedPixels: [UInt8]) {
+        guard isReady, let connection else {
+            connect()
+            return
+        }
+
+        var payload = Data()
+        payload.reserveCapacity(pushDisplayMirrorHeaderByteCount + encodedPixels.count)
+        payload.append(pushDisplayMirrorMagic)
+        var length = UInt32(encodedPixels.count).bigEndian
+        withUnsafeBytes(of: &length) { payload.append(contentsOf: $0) }
+        payload.append(contentsOf: encodedPixels)
+
+        connection.send(content: payload, completion: .contentProcessed { [weak self] error in
+            guard let error else { return }
+            NSLog("PushDisplayTCPFrameSink: send failed: \(error)")
+            self?.queue.async { self?.reconnect() }
+        })
+    }
+
+    deinit {
+        connection?.cancel()
+    }
+}
+
+/// Receives encoded Push display frames from `PushDisplayTCPFrameSink`.
+public final class PushDisplayTCPFrameServer {
+    private let port: NWEndpoint.Port
+    private weak var sink: PushDisplayFrameSink?
+    private let queue = DispatchQueue(label: "PushDisplayTCPFrameServer")
+    private var listener: NWListener?
+    private var connections: [NWConnection] = []
+
+    private final class ConnectionState {
+        var buffer = Data()
+    }
+
+    public init(port: UInt16 = 48484, sink: PushDisplayFrameSink) {
+        self.port = NWEndpoint.Port(rawValue: port)!
+        self.sink = sink
+    }
+
+    public func start() throws {
+        let listener = try NWListener(using: .tcp, on: port)
+        listener.newConnectionHandler = { [weak self] connection in
+            self?.accept(connection)
+        }
+        listener.start(queue: queue)
+        self.listener = listener
+    }
+
+    public func stop() {
+        listener?.cancel()
+        listener = nil
+        connections.forEach { $0.cancel() }
+        connections.removeAll()
+    }
+
+    private func accept(_ connection: NWConnection) {
+        connections.append(connection)
+        let state = ConnectionState()
+
+        connection.stateUpdateHandler = { [weak self, weak connection] state in
+            if case .cancelled = state, let connection {
+                self?.connections.removeAll { $0 === connection }
+            }
+        }
+
+        connection.start(queue: queue)
+        receive(from: connection, state: state)
+    }
+
+    private func receive(from connection: NWConnection, state: ConnectionState) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { [weak self] data, _, isComplete, error in
+            guard let self else { return }
+            if let data, !data.isEmpty {
+                state.buffer.append(data)
+                self.deliverFrames(from: &state.buffer)
+            }
+
+            if isComplete || error != nil {
+                connection.cancel()
+                return
+            }
+
+            self.receive(from: connection, state: state)
+        }
+    }
+
+    private func deliverFrames(from buffer: inout Data) {
+        while buffer.count >= pushDisplayMirrorHeaderByteCount {
+            let base = buffer.startIndex
+            let magicEnd = buffer.index(base, offsetBy: 4)
+            guard buffer[base..<magicEnd] == pushDisplayMirrorMagic else {
+                buffer.removeFirst()
+                continue
+            }
+
+            let lengthStart = magicEnd
+            let lengthEnd = buffer.index(lengthStart, offsetBy: 4)
+            let frameLength = buffer[lengthStart..<lengthEnd].reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+            let totalLength = pushDisplayMirrorHeaderByteCount + Int(frameLength)
+            guard buffer.count >= totalLength else { return }
+
+            let payloadStart = lengthEnd
+            let payloadEnd = buffer.index(base, offsetBy: totalLength)
+            let encodedPixels = Array(buffer[payloadStart..<payloadEnd])
+            buffer.removeSubrange(base..<payloadEnd)
+
+            sink?.receive(pushDisplayFrame: PushDisplayFrame(encodedPixels: encodedPixels))
+        }
+    }
+
+    deinit {
+        stop()
+    }
+}

--- a/Sources/PushDisplayMirrorApp/main.swift
+++ b/Sources/PushDisplayMirrorApp/main.swift
@@ -1,0 +1,35 @@
+import AppKit
+import AbletonPushDisplayKit
+
+final class MirrorAppDelegate: NSObject, NSApplicationDelegate {
+    private var mirrorWindow: PushDisplayMirrorWindowController?
+    private var server: PushDisplayTCPFrameServer?
+
+    func applicationDidFinishLaunching(_: Notification) {
+        let mirrorWindow = PushDisplayMirrorWindowController()
+        self.mirrorWindow = mirrorWindow
+        mirrorWindow.showWindow(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        let port = UInt16(ProcessInfo.processInfo.environment["PUSHOS_MIRROR_PORT"] ?? "48484") ?? 48484
+        do {
+            let server = PushDisplayTCPFrameServer(port: port, sink: mirrorWindow)
+            try server.start()
+            self.server = server
+            NSLog("PushDisplayMirrorApp: listening on 127.0.0.1:\(port)")
+        } catch {
+            NSLog("PushDisplayMirrorApp: failed to listen: \(error)")
+            NSApp.terminate(nil)
+        }
+    }
+
+    func applicationWillTerminate(_: Notification) {
+        server?.stop()
+    }
+}
+
+let app = NSApplication.shared
+let delegate = MirrorAppDelegate()
+app.delegate = delegate
+app.setActivationPolicy(.regular)
+app.run()

--- a/Tests/AbletonPushDisplayKitTests/AbletonPushDisplayKitTests.swift
+++ b/Tests/AbletonPushDisplayKitTests/AbletonPushDisplayKitTests.swift
@@ -254,3 +254,60 @@ final class ConstantsTests: XCTestCase {
         XCTAssertEqual(TRANSFER_TIMEOUT, 1000)
     }
 }
+
+// MARK: - PushDisplayFrame Tests
+
+final class PushDisplayFrameTests: XCTestCase {
+
+    func testFrameMetadataMatchesPushPayload() {
+        XCTAssertEqual(PushDisplayFrame.width, 960)
+        XCTAssertEqual(PushDisplayFrame.height, 160)
+        XCTAssertEqual(PushDisplayFrame.rowPixelBytes, 1920)
+        XCTAssertEqual(PushDisplayFrame.rowPaddingBytes, 128)
+        XCTAssertEqual(PushDisplayFrame.rowStride, 2048)
+        XCTAssertEqual(PushDisplayFrame.encodedByteCount, 327_680)
+    }
+
+    func testFrameValidityChecksPayloadSize() {
+        let validFrame = PushDisplayFrame(encodedPixels: [UInt8](repeating: 0, count: PushDisplayFrame.encodedByteCount))
+        XCTAssertTrue(validFrame.isValidForPushDisplay)
+
+        let invalidFrame = PushDisplayFrame(encodedPixels: [UInt8](repeating: 0, count: PushDisplayFrame.encodedByteCount - 1))
+        XCTAssertFalse(invalidFrame.isValidForPushDisplay)
+    }
+
+    func testDecodesBlackFrameToRGBA() {
+        let bitmap = PixelExtractor.createTestBitmapDirect(red: 0, green: 0, blue: 0)
+        let frame = PushDisplayFrame(encodedPixels: PixelExtractor.getPixelsForPush(bitmap: bitmap))
+
+        let rgba = frame.decodedRGBA8888Bytes()
+
+        XCTAssertEqual(rgba.count, PushDisplayFrame.width * PushDisplayFrame.height * 4)
+        XCTAssertEqual(Array(rgba.prefix(4)), [0, 0, 0, 255])
+    }
+
+    func testDecodesWhiteFrameToRGBA() {
+        let bitmap = PixelExtractor.createTestBitmapDirect(red: 255, green: 255, blue: 255)
+        let frame = PushDisplayFrame(encodedPixels: PixelExtractor.getPixelsForPush(bitmap: bitmap))
+
+        let rgba = frame.decodedRGBA8888Bytes()
+
+        XCTAssertEqual(Array(rgba.prefix(4)), [255, 255, 255, 255])
+    }
+
+    func testManagerPublishesFramesToMirrorSinksWhenDisconnected() {
+        let manager = PushDisplayManager()
+        manager.disconnect()
+
+        let expectation = XCTestExpectation(description: "mirror sink receives frame")
+        let sink = ClosurePushDisplayFrameSink { frame in
+            XCTAssertEqual(frame.encodedPixels.count, PushDisplayFrame.encodedByteCount)
+            expectation.fulfill()
+        }
+        manager.addFrameSink(sink)
+
+        manager.sendPixels(pixels: [UInt8](repeating: 0, count: PushDisplayFrame.encodedByteCount))
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a fan-out point at the encoded Push display frame boundary so the same bytes sent to hardware can also be mirrored, recorded, streamed, or decoded for previews.

## What changed

- Adds `PushDisplayFrame` metadata for the 960×160 BGR565/XOR payload.
- Adds RGB888/RGBA8888 decoding helpers for canvas/native preview consumers.
- Adds `PushDisplayFrameSink` and `ClosurePushDisplayFrameSink`.
- Lets `PushDisplayManager` add/remove sinks and publish each frame before USB output.
- Makes the existing pixel extraction and disconnect APIs public where needed by downstream runtime clients.
- Adds unit coverage for frame metadata, decoding, and sink publication.

## Validation

- `swift test` in `AbletonPushDisplayKit` passes: 30 tests, 0 failures.
- `swift build` and `swift test` in the sibling `PushReactRuntime` worktree pass when paired with this DisplayKit branch.

## Follow-up

The companion PushReactRuntime changes live in the local worktree branch `push-display-mirroring`, but that repository currently has no git remote configured, so I could not open a GitHub PR for it yet.